### PR TITLE
Pull in upstream updates up to 7.6.1

### DIFF
--- a/lib/mongoid/clients/factory.rb
+++ b/lib/mongoid/clients/factory.rb
@@ -95,6 +95,10 @@ module Mongoid
             [MONGOID_WRAPPING_LIBRARY] + options[:wrapping_libraries]
           else
             [MONGOID_WRAPPING_LIBRARY]
+          end.tap do |wrap|
+            if defined?(::Rails) && ::Rails.respond_to?(:version)
+              wrap << { name: 'Rails', version: ::Rails.version }
+            end
           end
           options[:wrapping_libraries] = wrap_lib
         end

--- a/lib/mongoid/extensions/hash.rb
+++ b/lib/mongoid/extensions/hash.rb
@@ -163,6 +163,28 @@ module Mongoid
         true
       end
 
+      ALLOWED_TO_CRITERIA_METHODS = %i[
+        all all_in all_of and any_in any_of asc ascending
+        batch_size between
+        collation comment cursor_type
+        desc descending
+        elem_match eq exists extras
+        geo_spatial group gt gte
+        hint
+        in includes
+        limit lt lte
+        max_distance max_scan max_time_ms merge mod
+        ne near near_sphere nin no_timeout none none_of nor not not_in
+        offset only or order order_by
+        project
+        raw read reorder
+        scoped skip slice snapshot
+        text_search type
+        unscoped unwind
+        where with_size with_type without
+      ].freeze
+      private_constant :ALLOWED_TO_CRITERIA_METHODS
+
       # Convert this hash to a criteria. Will iterate over each keys in the
       # hash which must correspond to method on a criteria object. The hash
       # must also include a "klass" key.
@@ -174,7 +196,11 @@ module Mongoid
       def to_criteria
         criteria = Criteria.new(delete(:klass) || delete("klass"))
         each_pair do |method, args|
-          criteria = criteria.__send__(method, args)
+          method_sym = method.to_sym
+          unless ALLOWED_TO_CRITERIA_METHODS.include?(method_sym)
+            raise ArgumentError, "Method '#{method}' is not allowed in to_criteria"
+          end
+          criteria = criteria.public_send(method_sym, args)
         end
         criteria
       end

--- a/lib/mongoid/version.rb
+++ b/lib/mongoid/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mongoid
-  VERSION = "7.5.4"
+  VERSION = "7.6.1"
 end

--- a/spec/mongoid/clients/factory_spec.rb
+++ b/spec/mongoid/clients/factory_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 
 require "spec_helper"
 
@@ -26,6 +27,34 @@ describe Mongoid::Clients::Factory do
         expected_addresses.include?(address)
       end
       expect(ok).to be true
+    end
+  end
+
+  shared_examples_for 'includes rails wrapping library' do
+    context 'when Rails is available' do
+      around do |example|
+        rails_was_defined = defined?(::Rails)
+
+        if !rails_was_defined
+          module ::Rails
+            def self.version
+              '6.1.0'
+            end
+          end
+        end
+
+        example.run
+
+        if !rails_was_defined
+          Object.send(:remove_const, :Rails) if defined?(::Rails)
+        end
+      end
+
+      it 'adds Rails as another wrapping library' do
+        expect(client.options[:wrapping_libraries]).to include(
+          {'name' => 'Rails', 'version' => '6.1.0'},
+        )
+      end
     end
   end
 
@@ -116,6 +145,8 @@ describe Mongoid::Clients::Factory do
                 ]
               end
             end
+
+            it_behaves_like 'includes rails wrapping library'
           end
         end
 

--- a/spec/mongoid/clients/factory_spec.rb
+++ b/spec/mongoid/clients/factory_spec.rb
@@ -35,7 +35,7 @@ describe Mongoid::Clients::Factory do
       around do |example|
         rails_was_defined = defined?(::Rails)
 
-        if !rails_was_defined
+        if !rails_was_defined || !::Rails.respond_to?(:version)
           module ::Rails
             def self.version
               '6.1.0'


### PR DESCRIPTION
Merges substantive commits up to 7.6.1 from mongoid/mongodb.

Note: This bumps the version to 7.6, so the target should be changed away from 7.5-stable before merging.